### PR TITLE
Integrate LoRA into the codebase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 transformers>=4.25.1
 accelerate>=0.15.0
 pandarallel>=1.6.4
+peft


### PR DESCRIPTION
LoRA promises significant reductions in memory. Hopefully, it will help take us to higher-scale models such as 12B and 20B. Right now, this is fine as is, but with the one caveat that I'm not exactly sure how to have it such that the LoRA weights are properly merged with the model. `merge_weights=True` in the `LoraConfig` doesn't do the trick, it seems. I'll be looking into it further, but in the meantime, this should be good to at least test out LoRA's effects on VRAM usage.